### PR TITLE
Emily_backe -> development

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -7,18 +7,20 @@ import { GameModule } from './game/game.module';
 import { ChatGateway } from './chat/chat.gateway';
 import { DatabaseModule } from './database/database.module';
 import { ConfigModule } from '@nestjs/config';
+import { TestingModule } from './testing/testing.module';
 
 @Module({
 	imports: [
+		ConfigModule.forRoot({
+			isGlobal: true,
+			envFilePath: '.env',
+		}),
 		AuthModule,
 		DatabaseModule,
 		UserModule,
 		GameModule,
 		DatabaseModule,
-		ConfigModule.forRoot({
-			isGlobal: true,
-			envFilePath: '.env',
-		}),
+		TestingModule,
 	],
 	controllers: [],
 	providers: [GameModule, ChatGateway],

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -30,6 +30,14 @@ import { extname } from 'path';
 export class AuthController {
 	constructor(private readonly authService: AuthService, private readonly configService: ConfigService, private readonly userService: UserService) {}
 
+	// Checks whether the user is authorized using the jwtguard
+	// Returns: {loggedIn: true} on success - 401 Unauthorized on failure
+	@Get('check')
+	@UseGuards(JwtGuard)
+	async checkLoggedIn() {
+		return {loggedIn: true};
+	}
+
 	@Get('login')
 	@UseGuards(AuthGuard('fortytwo'))
 	async login() {console.log("It hereee");}

--- a/api/src/testing/testing.controller.ts
+++ b/api/src/testing/testing.controller.ts
@@ -1,0 +1,39 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { TestingService } from './testing.service';
+import { UserService } from 'src/user/user.service';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { User } from 'src/user/entities/user.entity';
+
+// !! DO NOT MAKE CALLS TO THIS ENDPOINT FOR REASONS OTHER THAN TESTING !!
+@Controller('testing')
+export class TestingController {
+	constructor(private readonly testingService: TestingService, private readonly userService: UserService) {}
+
+	// Adds a single test user to the database
+	@Post('user')
+	async addUser(@Body() user: CreateUserDto): Promise<User[]> {
+		return await this.userService.createUser({...user, avatar: "/uploads/default_avatar.png", status: "online"});
+	}
+
+	// Adds an array of test users to the database
+	@Post('users')
+	async addUsers(@Body() users: CreateUserDto[]): Promise<User[]> {
+		var tempUsers: User[] = [];
+		users.forEach(user => {
+			tempUsers.push({...user, avatar: "/uploads/default_avatar.png", status: "online"});
+		});
+		return await this.userService.createUser(tempUsers);
+	}
+
+	// Gets a single user with the given id from the database
+	@Get('user/:id')
+	async getUser(@Param('id') id: string): Promise<User> {
+		return await this.userService.findUserById(id);
+	}
+
+	// Gets an array of all users from the database
+	@Get('user')
+	async findAllUsers(): Promise <User[]> {
+		return await this.userService.findAllUsers();
+	}
+}

--- a/api/src/testing/testing.module.ts
+++ b/api/src/testing/testing.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TestingService } from './testing.service';
+import { TestingController } from './testing.controller';
+import { UserModule } from 'src/user/user.module';
+
+@Module({
+	controllers: [TestingController],
+	providers: [TestingService],
+	imports: [UserModule]
+})
+export class TestingModule {}

--- a/api/src/testing/testing.service.ts
+++ b/api/src/testing/testing.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TestingService {}

--- a/api/src/user/dto/create-user.dto.ts
+++ b/api/src/user/dto/create-user.dto.ts
@@ -1,1 +1,5 @@
-export class CreateUserDto {}
+export class CreateUserDto {
+	id: string;
+	
+	nickname: string;
+}

--- a/api/src/user/user.controller.ts
+++ b/api/src/user/user.controller.ts
@@ -54,6 +54,12 @@ export class UserController {
 	async getAvatar(@Req() req, @Res() res) {
 		const user = await this.userService.findUserById(req.user.id);
 		const file = createReadStream(join(process.cwd(), user.avatar));
+
+		// Return error 404 if the avatar doesn't exist
+		file.on('error', () => {
+			return res.status(HttpStatus.NOT_FOUND).json({message: 'Avatar not found', avatar: user.avatar});
+		})
+		
 		file.pipe(res);
 	}
 

--- a/api/src/user/user.service.ts
+++ b/api/src/user/user.service.ts
@@ -17,8 +17,7 @@ export class UserService {
 	} 
 
 	async createUser(userData: any) {
-		const newUser = await this.userRepo.create(userData);
-		const savedUser = await this.userRepo.save(newUser);
+		const savedUser = await this.userRepo.save(userData);
 		return savedUser;
 	}
 
@@ -31,6 +30,10 @@ export class UserService {
 		const user = await this.userRepo.findOne({where: {nickname :name}});
 		console.log(user);
 		return user;
+	}
+
+	async findAllUsers(): Promise<User[]> {
+		return await this.userRepo.find();
 	}
 
 	async updateStatus(id: string, newStatus: string) {


### PR DESCRIPTION
Added a simple error check on the /api/user/getAvatar endpoint that returns 404 not found if it couldn't open the file. The issue with where the default avatar is store on the backend still needs to be fixed. But it no longer crashes the backend.

Created the /api/auth/check endpoint which passes the JWT token through the guard. I understand @Franakin was already working on/is done with this. My implementation doesn't do anything with the frontend yet, so it can be replaced.

Created the endpoint /api/testing. On it you can add a single user, add an array of users, view a user by id and view all users to/from the database. Please do not use this endpoint to for anything that's not "manually" adding/viewing users, since it does not check for the jwt token, making it very unsafe.