### PR TITLE
.dockerignore

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,2 @@
+./node_modules/*
+./package-lock.json

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+./node_modules/*
+./package-lock.json


### PR DESCRIPTION
added .dockerignore files with the node_modules and package-lock.json, because they should be ignored with the COPY . . call in the dockerfile