### PR TITLE
Made a separate entity for stats, for efficiency and keeping track of rating/ranking

### DIFF
--- a/api/src/database/database.module.ts
+++ b/api/src/database/database.module.ts
@@ -6,6 +6,7 @@ import { Block } from 'src/block/entities/block.entity';
 import { ChatRoom } from 'src/chat/entities/chatRoom.entity';
 import { FriendRequest } from 'src/friends/entities/friend.entity';
 import { Match } from 'src/game/entities/match.entity';
+import { MatchStats } from 'src/game/entities/stats.entity';
 import { User } from 'src/user/entities/user.entity';
 
 @Module({
@@ -28,6 +29,7 @@ import { User } from 'src/user/entities/user.entity';
 					refreshToken,
 					Block,
 					Match,
+					MatchStats,
 					ChatRoom,
 				],
 			})

--- a/api/src/game/Room.ts
+++ b/api/src/game/Room.ts
@@ -32,9 +32,9 @@ export class Room
 
 	moveBall()
 	{
-		if (this.ballSpeed[0] < 1 && this.ballSpeed[0] >= 0)
+		if (this.ballSpeed[0] < 1 && this.ballSpeed[0] > 0)
 			this.ballSpeed[0] = 1;
-		if (this.ballSpeed[0] > -1 && this.ballSpeed[0] <= 0)
+		if (this.ballSpeed[0] > -1 && this.ballSpeed[0] < 0)
 			this.ballSpeed[0] = -1;
 
 		this.ballPos[0] += this.ballSpeed[0];

--- a/api/src/game/entities/stats.entity.ts
+++ b/api/src/game/entities/stats.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+
+@Entity('stats')
+export class MatchStats {
+	@PrimaryColumn()
+	id: number;
+
+	@Column({default: 0})
+	wins: number;
+
+	@Column({default: 0})
+	losses: number;
+
+	@Column({default: 0}) // winning is +1 rating, losing is -1 rating
+	rating: number;
+}

--- a/api/src/game/game.module.ts
+++ b/api/src/game/game.module.ts
@@ -6,11 +6,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from 'src/user/user.module';
 import { MatchController } from './match.controller';
 import { MatchService } from './match.service';
+import { StatsService } from './stats.service';
+import { MatchStats } from './entities/stats.entity';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([Match]), UserModule, AuthModule, UserModule],
+	imports: [TypeOrmModule.forFeature([Match]), TypeOrmModule.forFeature([MatchStats]), UserModule, AuthModule, UserModule],
 	controllers: [MatchController],
-	providers: [GameGateway, MatchService],
+	providers: [GameGateway, MatchService, StatsService],
 	exports: [MatchService]
 })
 export class GameModule {}

--- a/api/src/game/match.service.ts
+++ b/api/src/game/match.service.ts
@@ -6,10 +6,12 @@ import { Match, MatchStatus } from './entities/match.entity';
 import { Repository } from 'typeorm';
 import { UserService } from 'src/user/user.service';
 import { User } from 'src/user/entities/user.entity';
+import { StatsService } from './stats.service';
+import { MatchStats } from './entities/stats.entity';
 
 @Injectable()
 export class MatchService {
-	constructor(@InjectRepository(Match) private readonly matchRepo: Repository<Match>, private readonly userService: UserService) {}
+	constructor(@InjectRepository(Match) private readonly matchRepo: Repository<Match>, private readonly userService: UserService, private readonly statsService: StatsService) {}
 	
 	async createMatch(createMatchDto: CreateMatchDto) {
 		// Games should only be create by the backend, these errors should never happen
@@ -70,8 +72,12 @@ export class MatchService {
 		let winner: User;
 		if (updateMatchDto.leftPlayerScore > updateMatchDto.rightPlayerScore) {
 			winner = match.leftPlayer;
+			this.statsService.updateWins(match.leftPlayer.id);
+			this.statsService.updateLosses(match.rightPlayer.id);
 		} else {
 			winner = match.rightPlayer;
+			this.statsService.updateWins(match.rightPlayer.id);
+			this.statsService.updateLosses(match.leftPlayer.id);
 		}
 		await this.matchRepo.update(
 			{id: updateMatchDto.id},
@@ -123,25 +129,23 @@ export class MatchService {
 		// console.log('User matches:\n', matches);
 		return matches;
 	}
-
+	
 	async getUserStats(targetId: number) {
-		const matches: Match[] = await this.getUserMatches(targetId);
-		if (matches.length == 0) {
-			return {
-				wins: 0,
-				losses: 0,
-				winrate: "n/a",
-			};
+		const user = await this.userService.findUserById(targetId);
+		if (!user){
+			throw new HttpException('User not found', 404);
 		}
-		let wins: number = 0;
-		matches.forEach((match) => {
-			if (match.winningPlayer.id == targetId)
-				wins++;
-		})
+		const stats: MatchStats = await this.statsService.getStats(targetId);
+		let winrate: string;
+		if (stats.wins + stats.losses == 0)
+			winrate = "n/a";
+		else
+			winrate = (stats.wins / (stats.wins + stats.losses) * 100).toFixed(2) + "%";
 		return {
-			wins: wins,
-			losses: matches.length - wins,
-			winrate: (wins / matches.length * 100).toFixed(2) + "%",
+			wins: stats.wins,
+			losses: stats.losses,
+			winrate: winrate,
+			ranking: await this.statsService.getRanking(targetId)
 		};
 	}
 

--- a/api/src/game/stats.service.ts
+++ b/api/src/game/stats.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from "@nestjs/common";
+import { MatchStats } from "./entities/stats.entity";
+import { Repository } from "typeorm";
+import { InjectRepository } from "@nestjs/typeorm";
+
+@Injectable()
+export class StatsService {
+	constructor(@InjectRepository(MatchStats) private readonly statsRepo: Repository<MatchStats>) {}
+
+	async createStats(userId: number): Promise<MatchStats> {
+		// Create stats giving the id the same value as the user id
+		const createdStats: MatchStats =  await this.statsRepo.save({
+			id: userId,
+		});
+		return createdStats;
+	}
+	
+	async getStats(userId: number): Promise<MatchStats> {
+		let stats: MatchStats = await this.statsRepo.findOne({where: {id: userId}});
+		// Create stats if the user doesn't have any yet
+		if (!stats) {
+			stats = await this.createStats(userId);
+		}
+		return stats;
+	}
+
+	async updateWins(userId: number) {
+		let stats: MatchStats = await this.getStats(userId);
+		await this.statsRepo.update({id: userId}, {wins: stats.wins + 1, rating: stats.rating + 1});
+	}
+
+	async updateLosses(userId: number) {
+		let stats: MatchStats = await this.getStats(userId);
+		await this.statsRepo.update({id: userId}, {losses: stats.losses + 1, rating: stats.rating - 1});
+	}
+	
+	async getRanking(userId: number): Promise<number> {
+		const stats: MatchStats = await this.getStats(userId);
+		const rating: number = stats.rating;
+		// QueryBuilder is vulnerable to sql injections, but this will only ever be called using value created on the backend
+		const ranking: number = await this.statsRepo.createQueryBuilder('stats')
+			.where('stats.rating >= :rating', {rating})
+			.getCount();
+		return ranking;
+	}
+}

--- a/frontend/src/app/components/user-detail/user-detail.component.html
+++ b/frontend/src/app/components/user-detail/user-detail.component.html
@@ -11,6 +11,7 @@
 			<button type="button" (click)="getMatches()">get match history</button>
 
 			@if (this.stats != undefined) {
+				<div><span>rank :</span> {{stats.ranking}} </div>
 				<div><span>wins :</span> {{stats.wins}} </div>
 				<div><span>losses :</span> {{stats.losses}} </div>
 				<div><span>winrate :</span> {{stats.winrate}} </div>

--- a/frontend/src/app/components/user-detail/user-detail.component.ts
+++ b/frontend/src/app/components/user-detail/user-detail.component.ts
@@ -26,7 +26,8 @@ export class UserDetailComponent implements OnChanges {
 	stats : undefined | {
 		wins : undefined,
 		losses : undefined,
-		winrate: undefined
+		winrate: undefined,
+		ranking: undefined
 	};
 
 	matches: any | undefined;


### PR DESCRIPTION
When getting the stats, it no longer gets all the matches the user has played and count wins/losses. It just updates the wins counter on a win, and the losses counter on a loss.
It also increments/decrements the rating value on a win/loss. This rating value then gets used to get a ranking compared with all other users.
Also fixed issue where the ball would move right slightly at the start of a round