### PR TITLE
Added a file size limit on backend and frontend to prevent crashes

### DIFF
--- a/frontend/src/app/components/settings/settings.component.ts
+++ b/frontend/src/app/components/settings/settings.component.ts
@@ -123,7 +123,7 @@ export class SettingsComponent implements OnInit {
 		if (selectedFiles) {
 			const file: File | null = selectedFiles.item(0);
 
-			if (file) {
+			if (file && file.size < 1 * 1024 * 1024) {
 				this.preview = '';
 				this.current_file = file;
 


### PR DESCRIPTION
When uploading many large files to the backend, it could run out of disk space and throw an internal server error.
I've added a file size limit to the "limits". And a content-length check in the "filefilter" to stop the file being saved before checking the size and deleting it.

On the frontend you could still upload a large file, even if the backend doesn't accept it. The issue is that it would try to load a preview and it would crash the browser with a big file.
I've also added a check for the file size before loading the preview, this stops the crashes