### PR TITLE
Refresh fix

### DIFF
--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -1,8 +1,6 @@
-import { Session, HttpStatus, Injectable, Req, Res, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MongoExpiredSessionError, Repository } from 'typeorm';
-import { User } from 'src/user/entities/user.entity';
-import { Request, Response } from 'express';
+import { Repository } from 'typeorm';
 import { UserService } from 'src/user/user.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
@@ -67,6 +65,11 @@ export class AuthService {
 					secret: this.configService.getOrThrow("JWT_REFRESH_SECRET"),
 				}
 			);
+			const user = await this.userService.userExists(payload.id);
+			if (!user) {
+				console.log('Refresh token valid, but user not found')
+				throw new NotFoundException();
+			}
 			return payload;
 		}
 		catch(error) {

--- a/api/src/user/user.service.ts
+++ b/api/src/user/user.service.ts
@@ -134,8 +134,6 @@ export class UserService {
 	}
 
 	async updateRoomKey(userId: number, roomKey: number) {
-		if (!await this.userExists(userId))
-			throw new HttpException("User not found!", 404);
 		await this.userRepo.update({id: userId}, {roomKey: roomKey});
 	}
 }


### PR DESCRIPTION
Fixed issue where if you connected to the game socket without valid tokens, it would cause an internal server error:
On disconnect it would call "updateRoomKey()" with the userid of a user that doesn't exist. This would throw an http exception, which wouldn't be caught. I removed the exception because updating an entity that doesn't exist, doesn't do anything anyway.

I then also fixed the way I found that issue:
After starting the server with an empty database, I still had a valid refresh token in my browser. Since the token was valid, I got a new access token. I could then go everywhere, and make calls for a userid that doesn't exist. Now the "verifyJwtRefreshToken()" function will also check if the id within the payload, is a valid user.